### PR TITLE
Provide options for taxonomy elements (terms)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "scripts": {
     "test": "jest",
     "build": "tsc",

--- a/src/fields/elements/getItemElementFields.ts
+++ b/src/fields/elements/getItemElementFields.ts
@@ -1,59 +1,89 @@
 import { ZObject } from 'zapier-platform-core';
 import { KontentBundle } from '../../types/kontentBundle';
 import { getContentTypeElements } from './getContentTypeElements';
-import { ContentTypeElements } from '@kontent-ai/management-sdk';
+import { ContentTypeElements, TaxonomyModels } from '@kontent-ai/management-sdk';
 import { Field } from '../field';
+import { getTaxonomyGroup } from '../../utils/taxonomies/getTaxonomyGroup';
 
-export const getItemElementFields = async (z: ZObject, bundle: KontentBundle<{}>, contentTypeId: string) =>
+export const getItemElementFields = (z: ZObject, bundle: KontentBundle<{}>, contentTypeId: string) =>
   getContentTypeElements(z, bundle, contentTypeId)
-    .then(elements => elements.map(getSimpleElementField));
+    .then(async elements => [elements, await getTermsForTaxonomyElements(z, bundle)(elements)] as const)
+    .then(([elements, termsByElementId]) => elements.map(getSimpleElementField(termsByElementId)));
+
+const getTermsForTaxonomyElements = (z: ZObject, bundle: KontentBundle<{}>) =>
+  (elements: readonly ContentTypeElements.ContentTypeElementModel[]) =>
+    Promise.all(elements
+      .filter(el => el.type === "taxonomy")
+      .map(async el => [el.id, await getTaxonomyGroup(z, bundle)((el as ContentTypeElements.ITaxonomyElement).taxonomy_group.id || '')] as const))
+      .then(entries => entries.map(([elId, group]) => [elId, group.terms.flatMap(createTermData)] as const))
+      .then(entries => new Map(entries));
+
+type TermData = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+const createTermData = (term: TaxonomyModels.Taxonomy): ReadonlyArray<TermData> => [
+  {
+    id: term.id,
+    name: term.name,
+  },
+  ...term.terms.flatMap(createTermData),
+];
 
 export type ElementFields = Readonly<{
   [key: `elements__${string}`]: string | string[] | number | undefined;
 }>;
 
-function getSimpleElementField(element: ContentTypeElements.ContentTypeElementModel) {
-  switch (element.type) {
-    case 'text':
-    case 'rich_text':
-    case 'custom':
-      return getField(element, { type: 'text' });
+const getSimpleElementField = (termsByElementId: ReadonlyMap<string, readonly TermData[]>) =>
+  (element: ContentTypeElements.ContentTypeElementModel) => {
+    switch (element.type) {
+      case 'text':
+      case 'rich_text':
+      case 'custom':
+        return getField(element, { type: 'text' });
 
-    case 'number':
-      return getField(element, { type: 'float' });
+      case 'number':
+        return getField(element, { type: 'float' });
 
-    case 'date_time':
-      return getField(element, { type: 'datetime' });
+      case 'date_time':
+        return getField(element, { type: 'datetime' });
 
-    case 'modular_content':
-      const opts = {
-        search: 'find_item.id',
-        list: true,
-        dynamic: 'get_linked_items.id.name',
-        type: 'string',
-        altersDynamicFields: false,
-      } as const;
+      case 'modular_content':
+        const opts = {
+          search: 'find_item.id',
+          list: true,
+          dynamic: 'get_linked_items.id.name',
+          type: 'string',
+          altersDynamicFields: false,
+        } as const;
 
-      return getField(element, opts);
+        return getField(element, opts);
 
-    case 'multiple_choice': {
-      const choices = element.options.map(o => ({ label: o.name, value: o.codename || '', sample: '' }));
+      case 'multiple_choice': {
+        const choices = element.options.map(o => ({ label: o.name, value: o.codename || '', sample: '' }));
 
-      return getField(element, { type: 'unicode', list: element.mode === 'multiple', choices });
+        return getField(element, { type: 'unicode', list: element.mode === 'multiple', choices });
+      }
+      case 'asset':
+        return getField(element, { type: 'unicode', list: true });
+
+      case 'taxonomy': {
+        const choices = (termsByElementId.get(element.id) ?? [])
+          .map(t => ({ value: t.id, label: t.name, sample: t.id }));
+
+        return getField(element, { type: 'unicode', choices, list: true });
+      }
+
+      case 'url_slug':
+        return getField(element, { type: 'unicode' });
+
+      case 'guidelines':
+        return getField(element, { type: 'copy' });
+      default:
+        return undefined;
     }
-    case 'asset':
-    case 'taxonomy':
-      return getField(element, { type: 'unicode', list: true });
-
-    case 'url_slug':
-      return getField(element, { type: 'unicode' });
-
-    case 'guidelines':
-      return getField(element, { type: 'copy' });
-    default:
-      return undefined;
   }
-}
 
 function getField(element: ElementWithoutSnippets, extra?: Partial<Field>) {
   const base = {

--- a/src/searches/findLanguage.ts
+++ b/src/searches/findLanguage.ts
@@ -80,6 +80,7 @@ export const findLanguage = {
   key: 'find_language',
   operation: {
     perform: execute,
+    outputFields,
     inputFields: [
       ...languageSearchFields,
     ],

--- a/src/utils/range.ts
+++ b/src/utils/range.ts
@@ -1,3 +1,3 @@
 export const range = (countOrStart: number, end?: number, step: number = 1) =>
-  [...new Array((end !== undefined ? Math.floor((end - countOrStart) / step) : countOrStart))]
+  [...new Array(end !== undefined ? Math.floor((end - countOrStart) / step) : countOrStart)]
     .map((_, i) => i * step);

--- a/src/utils/taxonomies/getTaxonomyGroup.ts
+++ b/src/utils/taxonomies/getTaxonomyGroup.ts
@@ -1,0 +1,10 @@
+import { ZObject } from "zapier-platform-core";
+import { KontentBundle } from "../../types/kontentBundle";
+import { createManagementClient } from "../kontentServices/managementClient";
+
+export const getTaxonomyGroup = (z: ZObject, bundle: KontentBundle<{}>) => (groupId: string) =>
+  createManagementClient(z, bundle)
+    .getTaxonomy()
+    .byTaxonomyId(groupId)
+    .toPromise()
+    .then(res => res.data);


### PR DESCRIPTION


### Motivation

Adds options for taxonomy elements. Fixes #13 

- it cannot be a dynamic dropdown, because there is no way to pass the dropdown info about the element it needs to fill => no way to know the taxonomy group to fetch

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Code has been tested in a private Zapier integration
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Check it is possible to correctly create an item with a taxonomy element and the input provides choices with the taxonomy group's terms.